### PR TITLE
PBI 28- Login Unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.1",
-    "jsdom": "^25.0.0",
-    "vite": "^5.4.0",
-    "vitest": "^2.0.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/user-event": "^14.6.1",
+    "@vitejs/plugin-react": "^4.3.1",
+    "jsdom": "^25.0.1",
+    "vite": "^5.4.0",
+    "vitest": "^2.1.9"
   },
   "scripts": {
     "dev": "vite",

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -1,0 +1,28 @@
+
+// This is the very first, minimal "smoke test" for the Login page.
+// Goal: Prove the component renders without crashing and shows the main H1 text.
+// We wrap <Login/> in a MemoryRouter because the component calls useNavigate(),
+// which requires a Router context even if we aren’t navigating in this test.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Login from '../../pages/auth/Login.jsx';
+
+describe('Login', () => {
+  it('renders the welcome title', () => {
+    // Render the page at a fake route so react-router hooks work.
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Login />
+      </MemoryRouter>
+    );
+
+    // Assertion: the main H1 should read "Welcome back".
+    // We use role-based query (more a11y-accurate) and a case-insensitive regex.
+    expect(
+      screen.getByRole('heading', { name: /welcome back/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -98,6 +98,32 @@ it('navigates to /dashboard and logs on button click', async () => {
 
   expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
 });
+// -- Step 5: keyboard activation (Enter/Space) --
+it('activates sign-in via Enter key', async () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
+  btn.focus();
+  await userEvent.keyboard('{Enter}');
+  expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+});
+
+it('activates sign-in via Space key', async () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
+  btn.focus();
+  await userEvent.keyboard(' ');
+  expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+});
 
 
 })

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -156,6 +156,49 @@ it('decorative image is presentational (alt="" + aria-hidden)', () => {
   expect(img).toHaveAttribute('alt', '');
   expect(img).toHaveAttribute('aria-hidden', 'true');
 });
+// -- Step 7: logs to console on click --
+it('logs "Login clicked" when the sign-in button is pressed', async () => {
+  const originalLog = console.log;
+  console.log = vi.fn();
+
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: /sign in with microsoft/i }));
+  expect(console.log).toHaveBeenCalledWith('Login clicked');
+
+  console.log = originalLog; // restore
+});
+
+// -- Step 8: button has correct aria-label AND visible text --
+it('exposes a precise aria-label and visible text for the sign-in button', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
+  expect(btn).toHaveAttribute('aria-label', 'Sign in with Microsoft'); // exact case
+  expect(screen.getByText('Sign in with Microsoft')).toBeInTheDocument(); // visible text node
+});
+
+// -- Step 9: section uses aria-labelledby that points to the H1 id --
+it('section aria-labelledby references the H1 id', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const section = screen.getByRole('region', { name: /welcome back/i });
+  const heading = screen.getByRole('heading', { name: /welcome back/i, level: 1 });
+
+  expect(section).toHaveAttribute('aria-labelledby', heading.id);
+});
 
 
 })

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -124,6 +124,38 @@ it('activates sign-in via Space key', async () => {
   await userEvent.keyboard(' ');
   expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
 });
+// -- Step 6: legal links, aside label, presentational image --
+
+it('renders legal links (Terms, Privacy Policy)', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('link', { name: /terms/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /privacy policy/i })).toBeInTheDocument();
+});
+
+it('aside has a descriptive aria-label', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+  expect(screen.getByLabelText(/brand illustration/i)).toBeInTheDocument();
+});
+
+it('decorative image is presentational (alt="" + aria-hidden)', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+  // Decorative images with alt="" + aria-hidden are role=presentation
+  const img = screen.getByRole('presentation', { hidden: true });
+  expect(img).toHaveAttribute('alt', '');
+  expect(img).toHaveAttribute('aria-hidden', 'true');
+});
 
 
 })

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -9,7 +9,15 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import Login from '../../pages/auth/Login.jsx';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 
+// mock react-router's useNavigate so we can assert the path
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 describe('Login', () => {
   it('renders the welcome title', () => {
     // Render the page at a fake route so react-router hooks work.
@@ -78,5 +86,18 @@ it('shows the Microsoft sign-in button with accessible name', () => {
   const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
   expect(btn).toBeEnabled(); // interactive and not disabled
 });
+// -- Step 4: click navigates to /dashboard --
+it('navigates to /dashboard and logs on button click', async () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: /sign in with microsoft/i }));
+
+  expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+});
+
 
 })

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -74,18 +74,7 @@ it('shows the Microsoft sign-in button with accessible name', () => {
   const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
   expect(btn).toBeEnabled(); // interactive and not disabled
 });
-// -- Step 3: button accessibility --
-// Confirms the Microsoft sign-in button is exposed with a clear accessible name.
-it('shows the Microsoft sign-in button with accessible name', () => {
-  render(
-    <MemoryRouter initialEntries={['/login']}>
-      <Login />
-    </MemoryRouter>
-  );
 
-  const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
-  expect(btn).toBeEnabled(); // interactive and not disabled
-});
 // -- Step 4: click navigates to /dashboard --
 it('navigates to /dashboard and logs on button click', async () => {
   render(

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -54,4 +54,29 @@ it('heading has the expected id (welcome-title)', () => {
   const heading = screen.getByRole('heading', { name: /welcome back/i, level: 1 });
   expect(heading.id).toBe('welcome-title');
 });
+// -- Step 3: button accessibility --
+// Confirms the Microsoft sign-in button is exposed with a clear accessible name.
+it('shows the Microsoft sign-in button with accessible name', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
+  expect(btn).toBeEnabled(); // interactive and not disabled
+});
+// -- Step 3: button accessibility --
+// Confirms the Microsoft sign-in button is exposed with a clear accessible name.
+it('shows the Microsoft sign-in button with accessible name', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const btn = screen.getByRole('button', { name: /sign in with microsoft/i });
+  expect(btn).toBeEnabled(); // interactive and not disabled
+});
+
 })

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -1,4 +1,4 @@
-
+// Step-1
 // This is the very first, minimal "smoke test" for the Login page.
 // Goal: Prove the component renders without crashing and shows the main H1 text.
 // We wrap <Login/> in a MemoryRouter because the component calls useNavigate(),
@@ -25,4 +25,33 @@ describe('Login', () => {
       screen.getByRole('heading', { name: /welcome back/i })
     ).toBeInTheDocument();
   });
+// Step 2: structure & branding assertions 
+
+// Proves the main landmark exists and key branding text is rendered.
+it('renders main landmark and branding text', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  // Landmark present
+  expect(screen.getByRole('main')).toBeInTheDocument();
+
+  // Branding present
+  expect(screen.getByText(/DELPHI/i)).toBeInTheDocument();
+  expect(screen.getByText(/Decision insights for Lifeblood/i)).toBeInTheDocument();
 });
+
+// Verifies the H1 has the expected id used by aria-labelledby on the section.
+it('heading has the expected id (welcome-title)', () => {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Login />
+    </MemoryRouter>
+  );
+
+  const heading = screen.getByRole('heading', { name: /welcome back/i, level: 1 });
+  expect(heading.id).toBe('welcome-title');
+});
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'dist',
-    sourcemap: true
+    sourcemap: true,
   },
   server: {
     port: 5173,
@@ -14,6 +14,10 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: './src/setupTests.js'
-  }
+    setupFiles: './src/setupTests.js',
+    css: true,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
 });


### PR DESCRIPTION
PBI-28 — Add unit tests for Login page

Introduce a focused test suite for Login.jsx to lock down rendering, navigation, and accessibility of the sign-in flow.

Changes
Added src/components/__tests__/Login.test.jsx
Used MemoryRouter for render tests and mocked useNavigate for deterministic navigation assertions
No runtime UI changes

Tests Included
Render & Structure

Renders H1 “Welcome back”
<main> landmark present
Branding text: “DELPHI” and “Decision insights for Lifeblood”
H1 has id="welcome-title" (used by aria-labelledby)

Behavior

Sign-in button is accessible/enabled
Click navigates to /dashboard
Keyboard: Enter and Space trigger navigation
Logs "Login clicked" on press (temporary side-effect until MSAL)

Accessibility

Button aria-label matches visible text
Section’s aria-labelledby references the H1 id
Aside labelled “Brand illustration”
Terms & Privacy links present
Decorative image is presentational (role="presentation", alt="", aria-hidden="true")